### PR TITLE
chore: add dependabot PR workflow for secret access after approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Entur/Helm/CI
 
 on:
   pull_request:
+  workflow_call:
 
 permissions:
   contents: write # required by entur/gha-meta auto-doc.yml

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,0 +1,21 @@
+# Dependabot pull request workflow
+#
+# Dependabot PRs do not receive repository secrets by default.
+# This workflow adds an approval gate so secrets are only exposed after a human has reviewed and approved the PR.
+
+name: Entur/Helm/CI/Dependabot
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: read
+  id-token: write
+
+jobs:
+  ci:
+    if: github.event.review.state == 'approved' && github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Adds `dependabot-pr.yml` workflow that triggers on PR review approval for dependabot PRs, running the full CI with `secrets: inherit`
- Adds `workflow_call` trigger to `ci.yml` so it can be invoked as a reusable workflow from the new dependabot workflow
- Dependabot PRs don't receive repository secrets by default, so deploy jobs that require OIDC auth fail. This approval gate ensures secrets are only exposed after a human review.

## Test plan
- [ ] Verify CI still triggers normally on non-dependabot PRs
- [ ] Verify approving a dependabot PR triggers the full CI pipeline with secrets