### PR TITLE
chore: skip CI for dependabot PRs before approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,21 @@ permissions:
 jobs:
   verify-pr:
     name: Verify PR
-    if: ${{ github.event_name == 'pull_request' }}
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     uses: entur/gha-meta/.github/workflows/verify-pr.yml@v1
   test-lint-ok-gcp:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/lint.yml
     with:
       environment: dev
       chart: fixture/helm/amazing-app
   test-unittest-ok:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/unittest.yml
     with:
       chart: fixture/helm/amazing-app-az
   test-lint-ok-multi:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/lint.yml
     with:
       environment: dev
@@ -51,7 +54,7 @@ jobs:
     secrets: inherit
 
   cleanup-deploy-gcp-multi:
-    if: always()
+    if: always() && needs.test-deploy-ok-gcp-multi.result != 'skipped'
     needs: [test-deploy-ok-gcp-multi]
     runs-on: ubuntu-24.04
     environment: dev
@@ -145,7 +148,7 @@ jobs:
 
   cleanup-deploy-gcp:
     # run regardless of previous job status
-    if: always()
+    if: always() && needs.test-deploy-ok-gcp.result != 'skipped'
     needs: [test-deploy-ok-gcp, test-deploy-gcp-no-image-update]
     runs-on: ubuntu-24.04
     environment: dev
@@ -185,7 +188,7 @@ jobs:
       namespace: ghaci
     secrets: inherit
   cleanup-deploy-azure:
-    if: always()
+    if: always() && needs.test-deploy-ok-azure.result != 'skipped'
     needs: [test-deploy-ok-azure]
     runs-on: ubuntu-24.04
     environment: az-dev


### PR DESCRIPTION
## Summary
- Skip all CI jobs when `github.actor` is `dependabot[bot]` (root jobs get `if` guard, dependent jobs auto-skip)
- Change cleanup jobs from `if: always()` to also check deploy wasn't skipped, so they don't attempt cloud auth without secrets
- CI runs normally after approval via `dependabot-pr.yml` (where `github.actor` is the reviewer)

Fixes the Slack token failure seen on [PR #99](https://github.com/entur/gha-helm/actions/runs/24503501885/job/71616155316?pr=99)

## Test plan
- [ ] Verify dependabot PRs skip CI on `pull_request`
- [ ] Verify approving a dependabot PR triggers full CI via `dependabot-pr.yml`
- [ ] Verify regular PRs still run CI normally