### PR TITLE
Feat/rollback on workflow cancel

### DIFF
--- a/.github/actions/helm-deploy/action.yml
+++ b/.github/actions/helm-deploy/action.yml
@@ -162,32 +162,11 @@ runs:
             exit 1
           fi
         fi
-    # Rolls back the Helm release if the job is cancelled during deployment and a previous release exists
     - id: helm-rollback-on-cancel
       name: Helm rollback on cancellation
       if: cancelled() && steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '0'
-      env:
-        TIMEOUT: ${{ inputs.timeout_minutes }}
-        GHA_HELM_DEPLOY_RELEASE_NAME: ${{ inputs.release_name }}
-        GHA_HELM_DEPLOY_NAMESPACE: ${{ inputs.namespace }}
-      shell: bash
-      run: |
-        TIMEOUT=$((TIMEOUT/2-2))
-        if (( TIMEOUT < 1 )); then TIMEOUT=1; fi
-        if (( TIMEOUT > 4 )); then TIMEOUT=4; fi
-        if helm list --all -n "${GHA_HELM_DEPLOY_NAMESPACE}" --filter "^${GHA_HELM_DEPLOY_RELEASE_NAME}$" --short | grep -q .; then
-          echo "#################################################################################################"
-          echo " Job cancelled. Rolling back Helm release '${GHA_HELM_DEPLOY_RELEASE_NAME}'..."
-          echo "#################################################################################################"
-          if helm rollback "${GHA_HELM_DEPLOY_RELEASE_NAME}" --namespace "${GHA_HELM_DEPLOY_NAMESPACE}" --wait --timeout "${TIMEOUT}m0s" --debug; then
-            echo "#################################################################################################"
-            echo " Helm rollback on cancellation successful."
-            echo "#################################################################################################"
-          else
-            echo "#################################################################################################"
-            echo " Helm rollback on cancellation failed. Please investigate manually."
-            echo "#################################################################################################"
-          fi
-        else
-          echo "No existing Helm release found for '${GHA_HELM_DEPLOY_RELEASE_NAME}' in '${GHA_HELM_DEPLOY_NAMESPACE}'. Nothing to roll back."
-        fi
+      uses: ./.github/actions/helm-rollback-on-cancel
+      with:
+        release_name: ${{ inputs.release_name }}
+        namespace: ${{ inputs.namespace }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/actions/helm-deploy/action.yml
+++ b/.github/actions/helm-deploy/action.yml
@@ -162,3 +162,32 @@ runs:
             exit 1
           fi
         fi
+    # Rolls back the Helm release if the job is cancelled during deployment and a previous release exists
+    - id: helm-rollback-on-cancel
+      name: Helm rollback on cancellation
+      if: cancelled() && steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '0'
+      env:
+        TIMEOUT: ${{ inputs.timeout_minutes }}
+        GHA_HELM_DEPLOY_RELEASE_NAME: ${{ inputs.release_name }}
+        GHA_HELM_DEPLOY_NAMESPACE: ${{ inputs.namespace }}
+      shell: bash
+      run: |
+        TIMEOUT=$((TIMEOUT/2-2))
+        if (( TIMEOUT < 1 )); then TIMEOUT=1; fi
+        if (( TIMEOUT > 4 )); then TIMEOUT=4; fi
+        if helm list --all -n "${GHA_HELM_DEPLOY_NAMESPACE}" --filter "^${GHA_HELM_DEPLOY_RELEASE_NAME}$" --short | grep -q .; then
+          echo "#################################################################################################"
+          echo " Job cancelled. Rolling back Helm release '${GHA_HELM_DEPLOY_RELEASE_NAME}'..."
+          echo "#################################################################################################"
+          if helm rollback "${GHA_HELM_DEPLOY_RELEASE_NAME}" --namespace "${GHA_HELM_DEPLOY_NAMESPACE}" --wait --timeout "${TIMEOUT}m0s" --debug; then
+            echo "#################################################################################################"
+            echo " Helm rollback on cancellation successful."
+            echo "#################################################################################################"
+          else
+            echo "#################################################################################################"
+            echo " Helm rollback on cancellation failed. Please investigate manually."
+            echo "#################################################################################################"
+          fi
+        else
+          echo "No existing Helm release found for '${GHA_HELM_DEPLOY_RELEASE_NAME}' in '${GHA_HELM_DEPLOY_NAMESPACE}'. Nothing to roll back."
+        fi

--- a/.github/actions/helm-deploy/action.yml
+++ b/.github/actions/helm-deploy/action.yml
@@ -162,11 +162,3 @@ runs:
             exit 1
           fi
         fi
-    - id: helm-rollback-on-cancel
-      name: Helm rollback on cancellation
-      if: cancelled() && steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '0'
-      uses: ./.github/actions/helm-rollback-on-cancel
-      with:
-        release_name: ${{ inputs.release_name }}
-        namespace: ${{ inputs.namespace }}
-        timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/.github/actions/helm-rollback-on-cancel/action.yml
+++ b/.github/actions/helm-rollback-on-cancel/action.yml
@@ -1,0 +1,41 @@
+name: Entur/Helm/Rollback-On-Cancel
+description: Rolls back the Helm release if the job is canceled during deployment and a pending rollout exists
+inputs:
+  release_name:
+    description: "The release name"
+    required: true
+  namespace:
+    description: "The Kubernetes namespace"
+    required: true
+  timeout_minutes:
+    description: "Job timeout in minutes (same value as helm-deploy)."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        TIMEOUT: ${{ inputs.timeout_minutes }}
+        RELEASE_NAME: ${{ inputs.release_name }}
+        NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        TIMEOUT=$((TIMEOUT/2-2))
+        if (( TIMEOUT < 1 )); then TIMEOUT=1; fi
+        if (( TIMEOUT > 4 )); then TIMEOUT=4; fi
+        if helm list --pending -n "${NAMESPACE}" --filter "^${RELEASE_NAME}$" --short | grep -q .; then
+          echo "#################################################################################################"
+          echo " Job cancelled. Rolling back Helm release '${RELEASE_NAME}'..."
+          echo "#################################################################################################"
+          if helm rollback "${RELEASE_NAME}" --namespace "${NAMESPACE}" --wait --timeout "${TIMEOUT}m0s" --debug; then
+            echo "#################################################################################################"
+            echo " Helm rollback on cancellation successful."
+            echo "#################################################################################################"
+          else
+            echo "#################################################################################################"
+            echo " Helm rollback on cancellation failed. Please investigate manually."
+            echo "#################################################################################################"
+            exit 1
+          fi
+        else
+          echo "No active rollout found for '${RELEASE_NAME}' in '${NAMESPACE}'. Nothing to roll back."
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,8 +135,61 @@ jobs:
       slack_channel_id: GFBL95A0J # sandbox-channel
     secrets: inherit
 
-  test-deploy-gcp-with-failed-rollback:
+  test-deploy-gcp-cancel-rollback:
     needs: [test-deploy-ok-gcp]
+    runs-on: ubuntu-24.04
+    environment: dev
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - id: install
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: "v3.20.1"
+      - uses: entur/gha-meta/.github/actions/cloud-auth@v1
+        with:
+          environment: dev
+          gcp_workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: ${{ vars.SERVICE_ACCOUNT }}
+      - uses: entur/gha-meta/.github/actions/k8s-auth@v1
+        with:
+          environment: dev
+      - name: Put release in pending-upgrade state
+        run: |
+          helm upgrade amazing-app ./fixture/helm/amazing-app \
+            -f fixture/helm/amazing-app/env/values-kub-ent-dev.yaml \
+            --namespace gha-ci --install --wait --timeout 10m \
+            --set "common.container.image=eu.gcr.io/entur-system-1287/nonexistent:dummy" &
+          HELM_PID=$!
+          for i in $(seq 1 15); do
+            STATUS=$(helm status amazing-app -n gha-ci -o json 2>/dev/null | jq -r '.info.status' 2>/dev/null || echo "")
+            [ "$STATUS" = "pending-upgrade" ] && break
+            sleep 1
+          done
+          kill -9 $HELM_PID 2>/dev/null || true
+          wait $HELM_PID 2>/dev/null || true
+          STATUS=$(helm status amazing-app -n gha-ci -o json | jq -r '.info.status')
+          if [ "$STATUS" != "pending-upgrade" ]; then
+            echo "::error::Setup failed: expected pending-upgrade, got '$STATUS'"
+            exit 1
+          fi
+      - id: rollback-on-cancel
+        uses: ./.github/actions/helm-rollback-on-cancel
+        with:
+          release_name: amazing-app
+          namespace: gha-ci
+          timeout_minutes: 10
+      - name: Check rollback on cancel succeeded
+        if: steps.rollback-on-cancel.outcome != 'success'
+        uses: actions/github-script@v9
+        with:
+          script: core.setFailed('Rollback on cancel should succeed.')
+
+  test-deploy-gcp-with-failed-rollback:
+    needs: [test-deploy-gcp-cancel-rollback]
     runs-on: ubuntu-24.04
     environment: dev
     timeout-minutes: 8

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -260,6 +260,16 @@ jobs:
           image_set_path: ${{ env.GHA_HELM_DEPLOY_IMAGE_SET_PATH }}
           container_name: ${{ env.GHA_HELM_DEPLOY_CONTAINER_NAME }}
           registry: ${{ env.GHA_HELM_DEPLOY_REGISTRY }}
+      # Helm rollback on workflow cancellation, only trigger if user cancels during deployment and the deployment
+      # has not succeeded, to avoid rolling back a successful deployment in case of cancel after rollout completion.
+      - id: helm-rollback-on-cancel
+        name: Helm rollback on cancellation
+        if: cancelled() && steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '0'
+        uses: entur/gha-helm/.github/actions/helm-rollback-on-cancel@v1
+        with:
+          release_name: ${{ env.GHA_HELM_DEPLOY_RELEASE_NAME }}
+          namespace: ${{ env.GHA_HELM_DEPLOY_NAMESPACE }}
+          timeout_minutes: ${{ inputs.timeout_minutes }}
       - uses: entur/gha-meta/.github/actions/posthog@v1
         id: send-analytics
         name: Send analytics to PostHog

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,7 +265,7 @@ jobs:
       - id: helm-rollback-on-cancel
         name: Helm rollback on cancellation
         if: cancelled() && steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '0'
-        uses: entur/gha-helm/.github/actions/helm-rollback-on-cancel@v1
+        uses: ./.github/actions/helm-rollback-on-cancel
         with:
           release_name: ${{ env.GHA_HELM_DEPLOY_RELEASE_NAME }}
           namespace: ${{ env.GHA_HELM_DEPLOY_NAMESPACE }}


### PR DESCRIPTION
Endringer som legger til automatisk Helm-rollback hvis en bruker **kansellerer workflowen midt under en deployment-rollout.**

Sjekker om det finnes et **pending** Helm-release (helm list --pending). Hvis ja, kjøres helm rollback tilbake til forrige aktive versjon. Hvis ikke, så gjør den ingenting ("Nothing to roll back").

Opprettet som egen composite action for å gjøre den enklere å teste.

Det er litt edge-case, men ikke uhørt at man som bruker observerer noen rariteter i loggen eller på Grafana under en rollout som ikke direkte feiler deployment, men som gjør at bruker har lyst til å stoppe rollout av tenkelig problematisk versjon. Prøver å kopiere hvordan Harness håndterer kansellerte workflows under en rollout.