### PR TITLE
chore: run amazing-app-containers fixture pod as uid 101

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       slack_channel_id: GFBL95A0J # sandbox-channel
     secrets: inherit
 
-  test-deploy-gcp-with-failed-rollback:
+  test-deploy-gcp-with-rollback:
     needs: [test-deploy-ok-gcp]
     runs-on: ubuntu-24.04
     environment: dev
@@ -166,17 +166,23 @@ jobs:
           image: mybadimage:dummy
           release_name: amazing-app
           chart: fixture/helm/amazing-app
+          # Calling the composite action directly bypasses deploy.yml's
+          # set-values-file step, so resolve the dev values file explicitly.
+          # Without this the deploy fails on a missing values file instead of
+          # the bad image, so no failed revision is created and the rollback
+          # is non-deterministic (status 2 vs 3) depending on leftover state.
+          values: values-kub-ent-dev.yaml
           namespace: gha-ci
       - name: Check if rollback did succeed
-        if: steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '3'
+        if: steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '2'
         uses: actions/github-script@v9
         with:
           script: |
-            core.setFailed('Rollback should fail.')
+            core.setFailed('Rollback did not succeed.')
 
   test-deploy-gcp-no-image-update:
-    if: (success() || failure()) && needs.test-deploy-gcp-with-failed-rollback.result == 'success'
-    needs: [test-deploy-gcp-with-failed-rollback]
+    if: (success() || failure()) && needs.test-deploy-gcp-with-rollback.result == 'success'
+    needs: [test-deploy-gcp-with-rollback]
     uses: ./.github/workflows/deploy.yml
     concurrency:
       group: ${{ github.head_ref }}-gcp
@@ -212,7 +218,7 @@ jobs:
           cloud_provider: gcp
       - id: clean
         run: |
-          helm uninstall amazing-app -n gha-ci
+          helm uninstall amazing-app -n gha-ci --ignore-not-found
 
   test-deploy-ok-azure:
     needs: [test-lint-ok-azure]

--- a/fixture/helm/amazing-app-containers/values.yaml
+++ b/fixture/helm/amazing-app-containers/values.yaml
@@ -4,6 +4,14 @@ common:
   team: example
   ingress:
     trafficType: public
+  # Before common v2.0.0 the pod securityContext read only container.uid
+  # (singular); uid on containers[] entries was ignored, so the pod ran as the
+  # default uid 1000 and getting-started:latest crash-loops as 1000 (a
+  # /var/cache/nginx permission error). containers[].uid is honored from
+  # v2.0.0 on — remove this container.uid once this fixture's common dependency
+  # is bumped to a release that includes that fix.
+  container:
+    uid: 101
   containers:
     - name: app
       uid: 101


### PR DESCRIPTION
The common chart's containers-array path ignores uid in containers[] entries; the pod securityContext only reads container.uid (singular) and fell back to the default 1000, which getting-started:latest cannot run as. This made test-deploy-ok-gcp-containers crash-loop and fail CI on every PR since the container_name feature was released in 1.6.0 (the feature's own PR ran the pre-release helm-deploy@v1 action, so the test never actually exercised the replacement).

This fixes the root cause for the failing https://github.com/entur/gha-helm/pull/120 (https://github.com/entur/gha-helm/actions/runs/27414274923/job/81022995404)