### PR TITLE
feat!: upgrade actions/checkout to version 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: install
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -175,7 +175,7 @@ jobs:
           namespace: gha-ci
       - name: Check if rollback did succeed
         if: steps.helm-deploy.outputs.HELM_DEPLOY_STATUS != '2'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             core.setFailed('Rollback did not succeed.')
@@ -251,13 +251,13 @@ jobs:
         with:
           version: "v3.20.1"
       - id: login-azure
-        uses: Azure/login@v3
+        uses: Azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - id: kubelogin-azure
-        uses: azure/use-kubelogin@v1
+        uses: azure/use-kubelogin@0ce7c36141aa27d4934872cf00b0120804c98a29 # v1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -252,10 +252,10 @@ jobs:
           echo "GitHub repository environment variable AZURE_CLUSTER_NAME is not set. Setup using tf-azure-apps. Exiting."
           exit 1
       - id: checkout-default-ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_GIT_REF == ''
       - id: checkout-specific-ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.GHA_GIT_REF != ''
         with:
           ref: ${{ env.GHA_GIT_REF }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: entur/gha-helm/.github/actions/helm-lint@v1
         with:
           environment: ${{ inputs.environment }}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,7 +26,7 @@ jobs:
         if: env.GHA_HELM_LINT_CHART == 'default'
         run: |
           echo "GHA_HELM_LINT_CHART=helm/${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - id: install
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:


### PR DESCRIPTION
## 💡 The problem
Vulnerabilty of pull_request target 

## 🔧 The solution

upgrade to version 7 that blocks it

## 💬 Additional notes

<!-- Other thoughts, concerns or relevant links -->

## 💣 Breaking changes (if applicable)

<!-- Describe what breaks and how to migrate -->
<!-- ⚠️ A breaking change needs a new major version:
     - the PR title must be `type!: ...`, or the description must contain a `BREAKING CHANGE: ...` footer
     - without it, release-please only cuts a patch/minor and consumers get the change silently on `@v1`
     - after release, update the examples in .github/README.md and README-{lint,deploy,unittest}.md to the new major version
<!-- Remove the section if not relevant -->
For most workflows this is not breaking, however if you are using pull_request_target, you need to fix this first.
See https://github.com/actions/checkout#whats-new for more information

## ✅ Checklist

<!-- Check off when the items are fulfilled -->

- [x] Docs are updated where auto-doc doesn't reach
- [x] Fixture app (`fixture/`) exercises the new behaviour, if applicable
- [x] `.github/workflows/ci.yml` is updated if new behaviour is added
- [x] Third-party actions are pinned to a commit SHA, and workflow permissions are kept minimal
- [x] No secrets, project IDs or other sensitive values are hardcoded
